### PR TITLE
Fixed typos/inaccuracies in location names

### DIFF
--- a/src/main/java/com/themysterys/mcciutils/Global/LocationID.java
+++ b/src/main/java/com/themysterys/mcciutils/Global/LocationID.java
@@ -24,7 +24,7 @@ public class LocationID {
         switch (locationID) {
             // Lobbies
             case "MAIN ISLAND" -> {
-                return "In main lobby";
+                return "On the Main Island";
             }
             case "SLIME FACTORY" -> {
                 return "In HITW lobby";
@@ -44,11 +44,11 @@ public class LocationID {
                 return "Playing HITW";
             }
             case "BATTLE BOX" -> {
-                return "Player Battle Box";
+                return "Playing Battle Box";
             }
             // Limbo
             case "LIMBO" -> {
-                return "In limbo";
+                return "In Limbo";
             }
 
             default -> {


### PR DESCRIPTION
The main island name was not capitalised, and read "main lobby", whereas MCCi themselves style it as the "Main Island". Additionally there was a typo in the Battle Box in-game location name.